### PR TITLE
Add the current Spotify volume to the current track info

### DIFF
--- a/SpotifyControl.scpt
+++ b/SpotifyControl.scpt
@@ -130,6 +130,7 @@ on run argv
 				set info to info & "\n Duration: " & mytime & " ("& duration of current track & " seconds)" 
 				set info to info & "\n Now at:   " & nowAt
 				set info to info & "\n Player:   " & player state
+				set info to info & "\n Volume:   " & sound volume
 				if shuffling then set info to info & "\n Shuffle is on."
 				if repeating then set info to info & "\n Repeat is on."
 			end tell


### PR DESCRIPTION
This adds the current application volume to the output of `spotify info`.

Example:

```
Current track:
 Artist:   Neil Young
 Track:    Rockin' In The Free World
 Album:    Freedom
 URI:      spotify:track:4Y7fEQ4PAzhlLnLviRw2P4
 Duration: 4min 42s (282 seconds)
 Now at:   0min 2s
 Player:   paused
 Volume:   76
 Shuffle is on.
```
