### PR TITLE
Fixed track duration to now handle milliseconds.

### DIFF
--- a/SpotifyControl
+++ b/SpotifyControl
@@ -142,8 +142,8 @@ on run argv
         set myTrack to name of current track
         set myArtist to artist of current track
         set myAlbum to album of current track
-        set tM to round (duration of current track / 60) rounding down
-        set tS to duration of current track mod 60
+        set tM to round ((duration of current track / 1000) / 60) rounding down
+        set tS to round ((duration of current track / 1000) mod 60) rounding down
         set myTime to tM as text & "min " & tS as text & "s"
         set nM to round (player position / 60) rounding down
         set nS to round (player position mod 60) rounding down
@@ -153,7 +153,7 @@ on run argv
         set info to info & "\n Track:    " & myTrack
         set info to info & "\n Album:    " & myAlbum
         set info to info & "\n URI:      " & spotify url of current track
-        set info to info & "\n Duration: " & mytime & " ("& duration of current track & " seconds)"
+        set info to info & "\n Duration: " & mytime & " ("& (round ((duration of current track / 1000)) rounding down) & " seconds)"
         set info to info & "\n Now at:   " & nowAt
         set info to info & "\n Player:   " & player state
         set info to info & "\n Volume:   " & sound volume


### PR DESCRIPTION
Spotify returns milliseconds now, which is why the calculations for the
duration of the track in the „info“ command were off.